### PR TITLE
Add state dump representation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,5 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add CHANGELOG file for tracking relevant user-facing changes
+- Add `State` struct for representing bspwm state dump
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ pub mod properties;
 pub mod query;
 pub mod selectors;
 pub mod settings;
-pub mod tree;
 pub mod state;
+pub mod tree;
 
 mod parser;
 mod socket;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod query;
 pub mod selectors;
 pub mod settings;
 pub mod tree;
+pub mod state;
 
 mod parser;
 mod socket;

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumString;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Rectangle {
     pub x: i32,
     pub y: i32,
@@ -9,7 +9,7 @@ pub struct Rectangle {
     pub height: i32,
 }
 
-#[derive(Debug, EnumString, Serialize, Deserialize)]
+#[derive(Debug, EnumString, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "snake_case")]
 pub enum Layout {
@@ -17,7 +17,7 @@ pub enum Layout {
     Monocle,
 }
 
-#[derive(Debug, EnumString, Serialize, Deserialize)]
+#[derive(Debug, EnumString, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "snake_case")]
 pub enum Dir {
@@ -27,7 +27,7 @@ pub enum Dir {
     East,
 }
 
-#[derive(Debug, EnumString, Serialize, Deserialize)]
+#[derive(Debug, EnumString, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "snake_case")]
 pub enum CycleDir {
@@ -35,28 +35,28 @@ pub enum CycleDir {
     Prev,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum SplitType {
     Vertical,
     Horizontal,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Presel {
     Dir(Dir),
     Ratio(f32),
     Cancel,
 }
 
-#[derive(Debug, EnumString)]
+#[derive(Debug, EnumString, Clone)]
 #[strum(serialize_all = "snake_case")]
 pub enum Stack {
     Below,
     Above,
 }
 
-#[derive(Debug, Serialize, Deserialize, EnumString)]
+#[derive(Debug, Serialize, Deserialize, EnumString, Clone)]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "snake_case")]
 pub enum State {
@@ -66,14 +66,14 @@ pub enum State {
     Fullscreen,
 }
 
-#[derive(Debug, EnumString)]
+#[derive(Debug, EnumString, Clone)]
 #[strum(serialize_all = "snake_case")]
 pub enum Switch {
     On,
     Off,
 }
 
-#[derive(Debug, Serialize, Deserialize, EnumString)]
+#[derive(Debug, Serialize, Deserialize, EnumString, Clone)]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "snake_case")]
 pub enum Flag {
@@ -85,7 +85,7 @@ pub enum Flag {
     Urgent,
 }
 
-#[derive(Debug, Serialize, Deserialize, EnumString)]
+#[derive(Debug, Serialize, Deserialize, EnumString, Clone)]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "snake_case")]
 pub enum Layer {
@@ -94,7 +94,7 @@ pub enum Layer {
     Above,
 }
 
-#[derive(Debug, EnumString)]
+#[derive(Debug, EnumString, Clone)]
 #[strum(serialize_all = "snake_case")]
 pub enum Action {
     Move,
@@ -102,7 +102,7 @@ pub enum Action {
     ResizeSide,
 }
 
-#[derive(Debug, EnumString)]
+#[derive(Debug, EnumString, Clone)]
 #[strum(serialize_all = "snake_case")]
 pub enum ActionState {
     Begin,

--- a/src/state.rs
+++ b/src/state.rs
@@ -19,7 +19,7 @@ pub struct FocusHistoryEntry {
 #[serde(rename_all = "camelCase")]
 pub struct State {
     pub focused_monitor_id: Id,
-    pub primary_monitor_id: Id,
+    pub primary_monitor_id: Option<Id>,
     pub clients_count: u32,
     pub monitors: Vec<Monitor>,
     pub focus_history: Vec<FocusHistoryEntry>,

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,9 +2,9 @@
 //! running `bspc wm -d` your shell.
 
 use crate::errors::ReplyError;
-use crate::socket::{connect, BspcCommunication};
+use crate::socket::BspcCommunication;
 use crate::tree::Monitor;
-use crate::Id;
+use crate::{socket, Id};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -19,6 +19,7 @@ pub struct FocusHistoryEntry {
 #[serde(rename_all = "camelCase")]
 pub struct State {
     pub focused_monitor_id: Id,
+    pub primary_monitor_id: Id,
     pub clients_count: u32,
     pub monitors: Vec<Monitor>,
     pub focus_history: Vec<FocusHistoryEntry>,
@@ -28,9 +29,8 @@ pub struct State {
 /// Returns a dump of the current bspwm state <br>
 /// Contains all monitors with their desktops (and window respectively)
 pub fn get_current_state() -> Result<State, ReplyError> {
-    let mut conn = connect()?;
-    let request = format!("wm\x00-d\x00");
-    conn.send_message(&request)?;
+    let mut conn = socket::connect()?;
+    conn.send_message("wm\x00-d\x00")?;
 
     let reply = conn.receive_message()?;
     let state: State = serde_json::from_str(&reply[0])?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,60 @@
+//! This module is dedicated for the state dump of bspwm. It can be received by 
+//! running `bspc wm -d` your shell.
+
+use serde::{Deserialize, Serialize};
+use crate::errors::ReplyError;
+use crate::Id;
+use crate::socket::{BspcCommunication, connect};
+use crate::tree::Monitor;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FocusHistoryEntry {
+    pub monitor_id: Id,
+    pub desktop_id: Id,
+    pub node_id: Id
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct State {
+    focused_monitor_id: Id,
+    clients_count: u32,
+    monitors: Vec<Monitor>,
+    focus_history: Vec<FocusHistoryEntry>,
+    stacking_list: Vec<Id>
+}
+
+/// Returns a dump of the current bspwm state <br>
+/// Contains all monitors with their desktops (and window respectively)
+pub fn get_current_state() -> Result<State, ReplyError> {
+    let mut conn = connect()?;
+    let request = format!("wm\x00-d\x00");
+    conn.send_message(&request)?;
+
+    let reply = conn.receive_message()?;
+    let state: State = serde_json::from_str(&reply[0])?;
+    Ok(state)
+}
+
+#[cfg(test)]
+mod test {
+    use std::process::Command;
+
+    use super::*;
+
+    #[test]
+    fn parse_state_dump() {
+        let state = Command::new("bspc")
+            .arg("wm")
+            .arg("-d")
+            .output()
+            .unwrap();
+        let state = std::str::from_utf8(&state.stdout).unwrap();
+
+        if state.len() > 1 {
+            let tree: State = serde_json::from_str(state).unwrap();
+            println!("{:#?}", tree);
+        }
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,18 +1,18 @@
-//! This module is dedicated for the state dump of bspwm. It can be received by 
+//! This module is dedicated for the state dump of bspwm. It can be received by
 //! running `bspc wm -d` your shell.
 
-use serde::{Deserialize, Serialize};
 use crate::errors::ReplyError;
-use crate::Id;
-use crate::socket::{BspcCommunication, connect};
+use crate::socket::{connect, BspcCommunication};
 use crate::tree::Monitor;
+use crate::Id;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FocusHistoryEntry {
     pub monitor_id: Id,
     pub desktop_id: Id,
-    pub node_id: Id
+    pub node_id: Id,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -22,7 +22,7 @@ pub struct State {
     pub clients_count: u32,
     pub monitors: Vec<Monitor>,
     pub focus_history: Vec<FocusHistoryEntry>,
-    pub stacking_list: Vec<Id>
+    pub stacking_list: Vec<Id>,
 }
 
 /// Returns a dump of the current bspwm state <br>
@@ -45,11 +45,7 @@ mod test {
 
     #[test]
     fn parse_state_dump() {
-        let state = Command::new("bspc")
-            .arg("wm")
-            .arg("-d")
-            .output()
-            .unwrap();
+        let state = Command::new("bspc").arg("wm").arg("-d").output().unwrap();
         let state = std::str::from_utf8(&state.stdout).unwrap();
 
         if state.len() > 1 {

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,11 +18,11 @@ pub struct FocusHistoryEntry {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct State {
-    focused_monitor_id: Id,
-    clients_count: u32,
-    monitors: Vec<Monitor>,
-    focus_history: Vec<FocusHistoryEntry>,
-    stacking_list: Vec<Id>
+    pub focused_monitor_id: Id,
+    pub clients_count: u32,
+    pub monitors: Vec<Monitor>,
+    pub focus_history: Vec<FocusHistoryEntry>,
+    pub stacking_list: Vec<Id>
 }
 
 /// Returns a dump of the current bspwm state <br>

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -4,7 +4,7 @@ use crate::errors::ReplyError;
 use crate::properties::{Dir, Layer, Layout, Rectangle, SplitType, State};
 use crate::Id;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Padding {
     pub top: i32,
     pub right: i32,
@@ -12,7 +12,7 @@ pub struct Padding {
     pub left: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Client {
     pub class_name: String,
@@ -28,20 +28,20 @@ pub struct Client {
     pub floating_rectangle: Rectangle,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Constraints {
     pub min_width: i32,
     pub min_height: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PreselNode {
     pub split_dir: Dir,
     pub split_ratio: f32,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Node {
     pub id: Id,
@@ -61,7 +61,7 @@ pub struct Node {
     pub client: Option<Client>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Desktop {
     pub name: String,
@@ -73,7 +73,7 @@ pub struct Desktop {
     pub root: Option<Node>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Monitor {
     pub name: String,


### PR DESCRIPTION
# Add state dump representation

Added `State` struct which represents a state dump of bspwm. This is useful for use cases which want to keep track of the bspwm state internally since it's an easy way to get the whole state at once instead of fetching every monitor, desktop and window individually.

> I added a test similar to the ones I've found in the `query` module but what's the use of them anyway since they don't make any assertions?

> This branch accidentally contains the content of the #1 PR as well. Therefore, it would be beneficial merging the #1 PR before this one

## Changes made
* Added `State` struct which represents a bspwm state dump
* Added `get_current_state` method for getting a `State` instance of the current bspwm state

